### PR TITLE
Update TinkerPop to latest patch release (3.4.8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre-alpine
 
-ENV GREMLIN_VERSION 3.4.1
+ENV GREMLIN_VERSION 3.4.8
 
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps wget unzip \


### PR DESCRIPTION
This adds new commands, such as elementMap. See https://tinkerpop.apache.org/docs/3.4.8/upgrade/